### PR TITLE
Fix GetGames and GetFoundGames

### DIFF
--- a/src/PinMame.Tests/Tests.cs
+++ b/src/PinMame.Tests/Tests.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -55,7 +56,7 @@ namespace PinMame
 		{
 			var games = _pinMame.GetGames();
 
-			Assert.IsTrue(games.Count > 650);
+			Assert.IsTrue(games.Count() > 650);
 		}
 
 		[TestMethod]
@@ -63,7 +64,7 @@ namespace PinMame
 		{
 			var games = _pinMame.GetFoundGames();
 
-			Assert.IsTrue(games.Count > 0);
+			Assert.IsTrue(games.Count() > 0);
 		}
 
 		[TestMethod]

--- a/src/PinMame/PinMameGame.cs
+++ b/src/PinMame/PinMameGame.cs
@@ -70,11 +70,11 @@ namespace PinMame
 		/// <summary>
 		/// Clones are ROMs of the same game but with a different version.
 		/// </summary>
-		public ICollection<PinMameGame> Clones => _clones.OrderBy(cloneGameInfo => cloneGameInfo.Description).ToList();
-
-		internal string CloneOf { get; }
+		public IEnumerable<PinMameGame> Clones => _clones;
 
 		public bool HasNoFlag => _flags == 0;
+
+		internal string CloneOf { get; }
 
 		private readonly uint _flags;
 		private readonly List<PinMameGame> _clones;


### PR DESCRIPTION
Before, `GetGames()` returned a sorted list. The problem is that the caller might don't need it sorted, or sorted the other way around, or any other LINQ query. In that case, we would have iterated through the list for nothing.

This PR returns an `IEnumerable`, which hasn't been iterated through yet.

I've also refactored the `GetGames` function a bit - now if a clone's parent isn't found, it'll be added as parent. I've also fixed the example code, since it was screwed up due to last PR's changes.