### PR TITLE
api: Replace Span<int> with PinMameLampInfo[]

### DIFF
--- a/src/PinMame.Example/PinMame.Example.csproj
+++ b/src/PinMame.Example/PinMame.Example.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.236" />
+    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.276" />
     <PackageReference Include="NLog" Version="4.7.10" />
   </ItemGroup>
 

--- a/src/PinMame.Tests/PinMame.Tests.csproj
+++ b/src/PinMame.Tests/PinMame.Tests.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform" Version="16.9.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.TestPlatform" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,7 +23,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.236" />
+    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.276" />
   </ItemGroup>
     
 </Project>

--- a/src/PinMame/PinMame.cs
+++ b/src/PinMame/PinMame.cs
@@ -413,15 +413,13 @@ namespace PinMame
 		{
 			Logger.Debug($"OnStateUpdatedCallback - state={state}");
 
-			if (state == 1)
-			{
+			if (state == 1) {
 				_changedLamps = new int[PinMameApi.PinmameGetMaxLamps() * 2];
 				_changedGIs = new int[PinMameApi.PinmameGetMaxGIs() * 2];
 
 				OnGameStarted?.Invoke();
 			}
-			else
-			{
+			else {
 				OnGameEnded?.Invoke();
 				RunningGame = null;
 			}
@@ -510,57 +508,45 @@ namespace PinMame
 		{
 			try
 			{
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-				{
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
 					var reg = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Classes\VPinMAME.Controller\CLSID");
-					if (reg != null)
-					{
+					if (reg != null) {
 						var clsId = reg.GetValue(null).ToString();
 						var x64Suffix = Environment.Is64BitOperatingSystem ? @"WOW6432Node\" : "";
 						reg = Registry.ClassesRoot.OpenSubKey(x64Suffix + @"CLSID\" + clsId + @"\InprocServer32");
-						if (reg != null)
-						{
+						if (reg != null) {
 							reg = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Freeware\Visual PinMame\globals");
 
-							if (reg != null)
-							{
+							if (reg != null) {
 								var path = reg.GetValue("rompath").ToString();
 
-								if (path.EndsWith(@"\roms"))
-								{
+								if (path.EndsWith(@"\roms")) {
 									return path.Substring(0, path.Length - 5);
 								}
-								else
-								{
+								else {
 									Logger.Warn($"Rom Path {path} last folder is not 'roms'");
 								}
 							}
-							else
-							{
+							else {
 								Logger.Warn($"Could not Rom Path in registry.");
 							}
 						}
-						else
-						{
+						else {
 							Logger.Warn($"Could not find CLSID {clsId} of VPinMAME.dll.");
 						}
 					}
-					else
-					{
+					else {
 						Logger.Warn("Looks like VPinMAME.Controller is not registered on the system!");
 					}
 				}
-				else
-				{
+				else {
 					var profilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 					var path = Path.GetFullPath(Path.Combine(profilePath, ".pinmame"));
 
-					if (Directory.Exists(path))
-					{
+					if (Directory.Exists(path)) {
 						return path;
 					}
-					else
-					{
+					else {
 						Logger.Warn($"Could not find .pinmame folder in {profilePath}");
 					}
 				}
@@ -600,10 +586,17 @@ namespace PinMame
 		/// The returned array contains pairs, where the first element is the
 		/// lamp number, and the second element the value.
 		/// </summary>
-		public Span<int> GetChangedLamps()
+		public PinMameLampInfo[] GetChangedLamps()
 		{
 			var num = PinMameApi.PinmameGetChangedLamps(_changedLamps);
-			return _changedLamps.AsSpan().Slice(0, num * 2);
+
+			PinMameLampInfo[] array = new PinMameLampInfo[num];
+
+			for (int index = 0; index < num; index++) {
+				array[index] = new PinMameLampInfo(_changedLamps[index * 2], _changedLamps[(index * 2) + 1]);
+			}
+
+			return array;
 		}
 
 		/// <summary>
@@ -618,10 +611,17 @@ namespace PinMame
 		/// The returned array contains pairs, where the first element is the
 		/// GI number, and the second element the value.
 		/// </summary>
-		public Span<int> GetChangedGIs()
+		public PinMameLampInfo[] GetChangedGIs()
 		{
 			var num = PinMameApi.PinmameGetChangedGIs(_changedGIs);
-			return _changedGIs.AsSpan().Slice(0, num * 2);
+
+			PinMameLampInfo[] array = new PinMameLampInfo[num];
+
+			for (int index = 0; index < num; index++) {
+				array[index] = new PinMameLampInfo(_changedGIs[index * 2], _changedGIs[(index * 2) + 1]);
+			}
+		
+			return array;
 		}
 
 		/// <summary>

--- a/src/PinMame/PinMame.csproj
+++ b/src/PinMame/PinMame.csproj
@@ -26,9 +26,8 @@
     <TargetOS Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</TargetOS>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0"/>
-    <PackageReference Include="System.Memory" Version="4.5.4"/>
-    <PackageReference Include="NLog" Version="4.7.10"/>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="NLog" Version="4.7.10" />
   </ItemGroup>
   <!-- Append target operating system to output path -->
   <PropertyGroup>
@@ -42,10 +41,10 @@
   </ItemGroup>
   <!-- Include .NET Standard packages on Linux and macOS -->
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.0\Linux\PinMame.dll" Pack="true" PackagePath="runtimes\linux\lib\netstandard2.0"/>
-    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.0\OSX\PinMame.dll" Pack="true" PackagePath="runtimes\osx\lib\netstandard2.0"/>
+    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.0\Linux\PinMame.dll" Pack="true" PackagePath="runtimes\linux\lib\netstandard2.0" />
+    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.0\OSX\PinMame.dll" Pack="true" PackagePath="runtimes\osx\lib\netstandard2.0" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
 </Project>

--- a/src/PinMame/PinMameLampInfo.cs
+++ b/src/PinMame/PinMameLampInfo.cs
@@ -1,0 +1,48 @@
+// pinmame-dotnet
+// Copyright (C) 1999-2021 PinMAME development team and contributors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+namespace PinMame
+{
+	public struct PinMameLampInfo
+	{
+		public readonly int Id;
+		public readonly int Value;
+
+		internal PinMameLampInfo(int id, int value)
+		{
+			Id = id;
+			Value = value;
+		}
+
+		public override string ToString() =>
+			$"Id={Id}, Value={Value}";
+	}
+}


### PR DESCRIPTION
This PR replaces both uses of `Span<int>` in favor of `PinMameLampInfo[]` which removes the dependency on `System.Memory`.