### PR TITLE
deps: bump to latest pinmame.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,16 +84,18 @@ void OnDisplayUpdated(int index, IntPtr framePtr, PinMameDisplayLayout displayLa
 };
 ```
 
-Some games add mechs regardless of the `g_fHandleMechanics` flag. 
-
 To add or update a mech:
 
 ```cs
+_pinMame.SetHandleMechanics(0);
+
 PinMameMechConfig mechConfig = new PinMameMechConfig(
-   (uint)(PinMameMechFlag.NONLINEAR | PinMameMechFlag.REVERSE | PinMameMechFlag.ONESOL),
+   (uint)(PinMameMechFlag.NonLinear | PinMameMechFlag.Reverse | PinMameMechFlag.OneSol),
    11,
    240,
    240,
+   0,
+   0,
    0);
 mechConfig.AddSwitch(new PinMameMechSwitchConfig(33, 0, 5));
 mechConfig.AddSwitch(new PinMameMechSwitchConfig(32, 98, 105));

--- a/src/PinMame.Example/Example.cs
+++ b/src/PinMame.Example/Example.cs
@@ -165,10 +165,12 @@ namespace PinMame
 			Logger.Info($"OnGameStarted");
 
 			PinMameMechConfig mechConfig = new PinMameMechConfig(
-				(uint)(PinMameMechFlag.NONLINEAR | PinMameMechFlag.REVERSE | PinMameMechFlag.ONESOL),
+				(uint)(PinMameMechFlag.NonLinear | PinMameMechFlag.Reverse | PinMameMechFlag.OneSol),
 				11,
 				240,
 				240,
+				0,
+				0,
 				0);
 			mechConfig.AddSwitch(new PinMameMechSwitchConfig(33, 0, 5));
 			mechConfig.AddSwitch(new PinMameMechSwitchConfig(32, 98, 105));
@@ -271,7 +273,7 @@ namespace PinMame
 
 			LogManager.ReconfigExistingLoggers();
 
-			_pinMame = PinMame.Instance(44100);
+			_pinMame = PinMame.Instance(PinMameAudioFormat.AudioFormatInt16, 44100);
 
 			_pinMame.SetHandleKeyboard(true);
 			_pinMame.SetHandleMechanics(0);

--- a/src/PinMame.Example/PinMame.Example.csproj
+++ b/src/PinMame.Example/PinMame.Example.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.307" />
+    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.311" />
     <PackageReference Include="NLog" Version="4.7.12" />
   </ItemGroup>
 

--- a/src/PinMame.Tests/PinMame.Tests.csproj
+++ b/src/PinMame.Tests/PinMame.Tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.307" />
+    <PackageReference Include="PinMame.Native" Version="3.4.0-preview.311" />
   </ItemGroup>
     
 </Project>

--- a/src/PinMame.Tests/Tests.cs
+++ b/src/PinMame.Tests/Tests.cs
@@ -48,7 +48,7 @@ namespace PinMame
 			var profilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 			var path = Path.GetFullPath(Path.Combine(profilePath, ".pinmame"));
 
-			_pinMame = PinMame.Instance(44100, path);
+			_pinMame = PinMame.Instance(PinMameAudioFormat.AudioFormatInt16, 44100, path);
 		}
 
 		[TestMethod]

--- a/src/PinMame/PinMame.cs
+++ b/src/PinMame/PinMame.cs
@@ -206,15 +206,16 @@ namespace PinMame
 		/// <summary>
 		/// Creates or retrieves the PinMame instance.
 		/// </summary>
+		/// <param name="audioFormat">Audio format (Int16 / Float)</param>
 		/// <param name="sampleRate">Audio sample rate</param>
 		/// <param name="vpmPath">Fallback path for VPM folder, if VPM is not registered</param>
 		/// <exception cref="ArgumentException">If VPM cannot be found</exception>
-		public static PinMame Instance(int sampleRate = 48000, string vpmPath = null) =>
-			_instance ?? (_instance = new PinMame(sampleRate, vpmPath));
+		public static PinMame Instance(PinMameAudioFormat audioFormat = PinMameAudioFormat.AudioFormatInt16, int sampleRate = 48000, string vpmPath = null) =>
+			_instance ?? (_instance = new PinMame(audioFormat, sampleRate, vpmPath));
 
-		private PinMame(int sampleRate, string vpmPath)
+		private PinMame(PinMameAudioFormat audioFormat, int sampleRate, string vpmPath)
 		{
-			Logger.Info($"PinMame - sampleRate={sampleRate}, vpmPath={vpmPath}");
+			Logger.Info($"PinMame - audioFormat={audioFormat}, sampleRate={sampleRate}, vpmPath={vpmPath}");
 
 			var path = vpmPath ?? GetVpmPath();
 			if (path == null) {
@@ -226,6 +227,7 @@ namespace PinMame
 			}
 
 			_config = new PinMameApi.PinmameConfig {
+				audioFormat = (PinMameApi.PinmameAudioFormat)audioFormat,
 				sampleRate = sampleRate,
 				vpmPath = path + Path.DirectorySeparatorChar,
 				onStateUpdated = OnStateUpdatedCallback,
@@ -703,7 +705,7 @@ namespace PinMame
 					mechConfig.sw[index].swNo = switchConfig.SwNo;
 					mechConfig.sw[index].startPos = switchConfig.StartPos;
 					mechConfig.sw[index].endPos = switchConfig.EndPos;
-					mechConfig.sw[index].pulse = switchConfig.Pulse ? 1 : 0;
+					mechConfig.sw[index].pulse = switchConfig.Pulse;
 
 					index++;
 				}

--- a/src/PinMame/PinMameApi.cs
+++ b/src/PinMame/PinMameApi.cs
@@ -56,6 +56,12 @@ namespace PinMame
 			MECH_NO_INVALID = 6
 		}
 
+		internal enum PinmameAudioFormat : int
+		{
+			AUDIO_FORMAT_INT16 = 0,
+			AUDIO_FORMAT_FLOAT = 1
+		}
+
 		internal enum PinmameDisplayType : int
 		{
 			SEG16 = 0,                  // 16 segments
@@ -182,7 +188,9 @@ namespace PinMame
 			TWOSTEPSOL = 0x40,
 			FOURSTEPSOL = (TWODIRSOL | TWOSTEPSOL),
 			SLOW = 0x00,
-			FAST = 0x80
+			FAST = 0x80,
+			STEPSW = 0x00,
+			LENGTHSW = 0x100
 		}
 
 		internal enum PinmameKeycode
@@ -344,6 +352,7 @@ namespace PinMame
 		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
 		internal struct PinmameConfig
 		{
+			internal PinmameAudioFormat audioFormat;
 			internal int sampleRate;
 			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 512)]
 			internal string vpmPath;
@@ -372,12 +381,14 @@ namespace PinMame
 		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
 		internal struct PinmameMechConfig
 		{
+			internal int type;
 			internal int sol1;
 			internal int sol2;
-			internal int type;
 			internal int length;
 			internal int steps;
 			internal int initialPos;
+			internal int acc;
+			internal int ret;
 			[MarshalAs(UnmanagedType.ByValArray, SizeConst = MaxMechSwitches)]
 			internal PinmameMechSwitchConfig[] sw;
 		}
@@ -397,6 +408,7 @@ namespace PinMame
 		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
 		internal readonly struct PinmameAudioInfo
 		{
+			internal readonly PinmameAudioFormat format;
 			internal readonly int channels;
 			internal readonly double sampleRate;
 			internal readonly double framesPerSecond;

--- a/src/PinMame/PinMameAudioInfo.cs
+++ b/src/PinMame/PinMameAudioInfo.cs
@@ -33,6 +33,7 @@ namespace PinMame
 {
 	public struct PinMameAudioInfo
 	{
+		public readonly PinMameAudioFormat Format;
 		public readonly int Channels;
 		public readonly double SampleRate;
 		public readonly double FramesPerSecond;
@@ -41,6 +42,7 @@ namespace PinMame
 
 		internal PinMameAudioInfo(PinMameApi.PinmameAudioInfo audioInfo)
 		{
+			Format = (PinMameAudioFormat)audioInfo.format;
 			Channels = audioInfo.channels;
 			SampleRate = audioInfo.sampleRate;
 			FramesPerSecond = audioInfo.framesPerSecond;
@@ -49,6 +51,6 @@ namespace PinMame
 		}
 
 		public override string ToString() =>
-			$"channels={Channels}, sampleRate={SampleRate}, framesPerSecond={FramesPerSecond}, samplesPerFrame={SamplesPerFrame}, bufferSize={BufferSize}";
+			$"format={Format}, channels={Channels}, sampleRate={SampleRate}, framesPerSecond={FramesPerSecond}, samplesPerFrame={SamplesPerFrame}, bufferSize={BufferSize}";
 	}
 }

--- a/src/PinMame/PinMameEnums.cs
+++ b/src/PinMame/PinMameEnums.cs
@@ -38,6 +38,13 @@ using System;
 namespace PinMame
 {
 	[Flags]
+	public enum PinMameAudioFormat
+	{
+		AudioFormatInt16 = PinMameApi.PinmameAudioFormat.AUDIO_FORMAT_INT16,
+		AudioFormatFloat = PinMameApi.PinmameAudioFormat.AUDIO_FORMAT_FLOAT
+	}
+
+	[Flags]
 	public enum PinMameDisplayType
 	{
 		/// <summary>
@@ -468,18 +475,20 @@ namespace PinMame
 
 	public enum PinMameMechFlag : uint
 	{
-		LINEAR = PinMameApi.PinmameMechFlag.LINEAR,
-		NONLINEAR = PinMameApi.PinmameMechFlag.NONLINEAR,
-		CIRCLE = PinMameApi.PinmameMechFlag.CIRCLE,
-		STOPEND = PinMameApi.PinmameMechFlag.STOPEND,
-		REVERSE = PinMameApi.PinmameMechFlag.REVERSE,
-		ONESOL = PinMameApi.PinmameMechFlag.ONESOL,
-		ONEDIRSOL = PinMameApi.PinmameMechFlag.ONEDIRSOL,
-		TWODIRSOL = PinMameApi.PinmameMechFlag.TWODIRSOL,
-		TWOSTEPSOL = PinMameApi.PinmameMechFlag.TWOSTEPSOL,
-		FOURSTEPSOL = PinMameApi.PinmameMechFlag.FOURSTEPSOL,
-		SLOW = PinMameApi.PinmameMechFlag.SLOW,
-		FAST = PinMameApi.PinmameMechFlag.FAST
+		Linear = PinMameApi.PinmameMechFlag.LINEAR,
+		NonLinear = PinMameApi.PinmameMechFlag.NONLINEAR,
+		Circle = PinMameApi.PinmameMechFlag.CIRCLE,
+		StopEnd = PinMameApi.PinmameMechFlag.STOPEND,
+		Reverse = PinMameApi.PinmameMechFlag.REVERSE,
+		OneSol = PinMameApi.PinmameMechFlag.ONESOL,
+		OneDirSol = PinMameApi.PinmameMechFlag.ONEDIRSOL,
+		TwoDirSol = PinMameApi.PinmameMechFlag.TWODIRSOL,
+		TwoStepSol = PinMameApi.PinmameMechFlag.TWOSTEPSOL,
+		FourStepSol = PinMameApi.PinmameMechFlag.FOURSTEPSOL,
+		Slow = PinMameApi.PinmameMechFlag.SLOW,
+		Fast = PinMameApi.PinmameMechFlag.FAST,
+		StepSw = PinMameApi.PinmameMechFlag.STEPSW,
+		LengthSw = PinMameApi.PinmameMechFlag.LENGTHSW
 	}
 
 	public enum PinMameKeycode

--- a/src/PinMame/PinMameMechConfig.cs
+++ b/src/PinMame/PinMameMechConfig.cs
@@ -39,9 +39,9 @@ namespace PinMame
 		public readonly int SwNo;
 		public readonly int StartPos;
 		public readonly int EndPos;
-		public readonly bool Pulse;
+		public readonly int Pulse;
 
-		public PinMameMechSwitchConfig(int swNo, int startPos, int endPos, bool pulse = false)
+		public PinMameMechSwitchConfig(int swNo, int startPos, int endPos, int pulse = 0)
 		{
 			SwNo = swNo;
 			StartPos = startPos;
@@ -58,9 +58,11 @@ namespace PinMame
 		public readonly int Length;
 		public readonly int Steps;
 		public readonly int InitialPos;
+		public readonly int Acc;
+		public readonly int Ret;
 		public readonly List<PinMameMechSwitchConfig> SwitchList;
 
-		public PinMameMechConfig(uint type, int sol1, int sol2, int length, int steps, int initialPos)
+		public PinMameMechConfig(uint type, int sol1, int sol2, int length, int steps, int initialPos, int acc, int ret)
 		{
 			Type = type;
 			Sol1 = sol1;
@@ -68,16 +70,20 @@ namespace PinMame
 			Length = length;
 			Steps = steps;
 			InitialPos = initialPos;
+			Acc = acc;
+			Ret = ret;
 			SwitchList = new List<PinMameMechSwitchConfig>();
 		}
 
-		public PinMameMechConfig(uint type, int sol1, int length, int steps, int initialPos)
+		public PinMameMechConfig(uint type, int sol1, int length, int steps, int initialPos, int acc, int ret)
 		{
 			Type = type;
 			Sol1 = sol1;
 			Length = length;
 			Steps = steps;
 			InitialPos = initialPos;
+			Acc = acc;
+			Ret = ret;
 			SwitchList = new List<PinMameMechSwitchConfig>();
 
 			Sol2 = 0;


### PR DESCRIPTION
The PR updates `pinmame-dot` to support the latest `libpinmame`

- add missing mech flags: `PinMameMechFlag.StepSw`, `PinMameMechFlag.LengthSw`
- adds Retardation (`ret`) and Acceleration (`acc`) to `PinMameMechConfig`
- adds `PinMameAudioFormat` to `PinMameConfig`

To request audio in `float[]` use `PinMameAudioFormat.AudioFormatFloat`
To request audio in `int16` use `PinMameAudioFormat.AudioFormatInt16`