### PR TITLE
Add support for il2cpp and iOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
             rid: osx-x64
           - os: macos-latest
             rid: osx-arm64
+          - os: macos-latest
+            rid: ios-arm64
           - os: ubuntu-latest
             rid: linux-x64
     steps:
@@ -39,9 +41,13 @@ jobs:
       - name: Build
         run: |
           cd src/PinMame.Tests
-          dotnet build -c Release -r ${{ matrix.rid }}
+          if [[ "${{ matrix.rid }}" == "ios-arm64" ]]; then
+            dotnet build -c Release -r ${{ matrix.rid }} /p:TargetOS=iOS
+          else
+            dotnet build -c Release -r ${{ matrix.rid }}
+          fi
       - name: Test
-        if: matrix.rid != 'osx-arm64'
+        if: matrix.rid != 'osx-arm64' && matrix.rid != 'ios-arm64'
         run: |
           mkdir -p ~/.pinmame/roms
           curl -sl https://www.ipdb.org/files/4032/mm_109c.zip -o ~/.pinmame/roms/mm_109c.zip

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -40,12 +40,14 @@ jobs:
           mv libpinmame-*-win-x86 libpinmame-win-x86
           mv libpinmame-*-osx-x64 libpinmame-osx-x64
           mv libpinmame-*-osx-arm64 libpinmame-osx-arm64
+          mv libpinmame-*-ios-arm64 libpinmame-ios-arm64
           mv libpinmame-*-linux-x64 libpinmame-linux-x64
           sed -i 's/__VERSION__/${{ needs.version.outputs.semver }}/g' *.nuspec
           nuget pack PinMame.Native.win-x64.nuspec -OutputDirectory nupkg
           nuget pack PinMame.Native.win-x86.nuspec -OutputDirectory nupkg
           nuget pack PinMame.Native.osx-x64.nuspec -OutputDirectory nupkg
           nuget pack PinMame.Native.osx-arm64.nuspec -OutputDirectory nupkg
+          nuget pack PinMame.Native.ios-arm64.nuspec -OutputDirectory nupkg
           nuget pack PinMame.Native.linux-x64.nuspec -OutputDirectory nupkg
           nuget pack PinMame.Native.nuspec -OutputDirectory nupkg
       - uses: actions/upload-artifact@v2
@@ -68,4 +70,5 @@ jobs:
           nuget push PinMame.Native.win-x86.${{ needs.version.outputs.semver }}.nupkg -ApiKey ${{ secrets.NUGET_KEY }} -src https://api.nuget.org/v3/index.json
           nuget push PinMame.Native.osx-x64.${{ needs.version.outputs.semver }}.nupkg -ApiKey ${{ secrets.NUGET_KEY }} -src https://api.nuget.org/v3/index.json
           nuget push PinMame.Native.osx-arm64.${{ needs.version.outputs.semver }}.nupkg -ApiKey ${{ secrets.NUGET_KEY }} -src https://api.nuget.org/v3/index.json
+          nuget push PinMame.Native.ios-arm64.${{ needs.version.outputs.semver }}.nupkg -ApiKey ${{ secrets.NUGET_KEY }} -src https://api.nuget.org/v3/index.json
           nuget push PinMame.Native.linux-x64.${{ needs.version.outputs.semver }}.nupkg -ApiKey ${{ secrets.NUGET_KEY }} -src https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
           ref: ${{ github.event.client_payload.commitish }}
       - run: |
           cd src/PinMame
+          dotnet build -c Release /p:TargetOS=iOS
           dotnet build -c Release /p:TargetOS=OSX
           dotnet build -c Release /p:TargetOS=Linux
           dotnet pack -c Release /p:TargetOS=Windows -o nupkg

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PinMAME for .NET
 
-[![CI status (x64 Linux, macOS and Windows)](https://github.com/VisualPinball/pinmame-dotnet/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/VisualPinball/pinmame-dotnet/actions) 
+[![CI status (x64 Linux, iOS, macOS and Windows)](https://github.com/VisualPinball/pinmame-dotnet/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/VisualPinball/pinmame-dotnet/actions) 
 [![NuGet](https://img.shields.io/nuget/vpre/PinMame.svg)](https://www.nuget.org/packages/PinMame)
 
 *Add PinMAME support to any .NET application*
@@ -12,7 +12,6 @@ This package is automatically built and published when the main project, PinMAME
 
 ## Supported Platforms
 
-- .NET Framework (4.5 and higher)
 - .NET Core (.NETStandard 2.1 and higher on Windows, Linux and macOS)
 - Mono
 
@@ -26,6 +25,7 @@ The native wrapper is a different package and contains pre-compiled binaries of 
 | **Windows 32-bit**    | [![PinMame.Native.win-x86-badge]][PinMame.Native.win-x86-nuget]     |
 | **macOS x64**         | [![PinMame.Native.osx-x64-badge]][PinMame.Native.osx-x64-nuget]     |
 | **macOS arm64**       | [![PinMame.Native.osx-arm64-badge]][PinMame.Native.osx-arm64-nuget] |
+| **iOS arm64**         | [![PinMame.Native.ios-arm64-badge]][PinMame.Native.ios-arm64-nuget] |
 | **Linux x64**         | [![PinMame.Native.linux-x64-badge]][PinMame.Native.linux-x64-nuget] |
 
 [PinMame.Native.win-x64-badge]: https://img.shields.io/nuget/vpre/PinMame.Native.win-x64.svg
@@ -36,6 +36,8 @@ The native wrapper is a different package and contains pre-compiled binaries of 
 [PinMame.Native.osx-x64-nuget]: https://www.nuget.org/packages/PinMame.Native.osx-x64
 [PinMame.Native.osx-arm64-badge]: https://img.shields.io/nuget/vpre/PinMame.Native.osx-arm64.svg
 [PinMame.Native.osx-arm64-nuget]: https://www.nuget.org/packages/PinMame.Native.osx-arm64
+[PinMame.Native.ios-arm64-badge]: https://img.shields.io/nuget/vpre/PinMame.Native.ios-arm64.svg
+[PinMame.Native.ios-arm64-nuget]: https://www.nuget.org/packages/PinMame.Native.ios-arm64
 [PinMame.Native.linux-x64-badge]: https://img.shields.io/nuget/vpre/PinMame.Native.linux-x64.svg
 [PinMame.Native.linux-x64-nuget]: https://www.nuget.org/packages/PinMame.Native.linux-x64
 

--- a/native/nuget/PinMame.Native.ios-arm64.nuspec
+++ b/native/nuget/PinMame.Native.ios-arm64.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
   <metadata>
     <!-- package -->
-    <id>PinMame.Native.linux-x64</id>
-    <title>PinMame - Native binaries for linux-x64</title>
+    <id>PinMame.Native.ios-arm64</id>
+    <title>PinMame - Native binaries for ios-arm64</title>
     <version>__VERSION__</version>
-    <description>This package complements the PinMame package and contains native binaries of libpinmame for linux-x64</description>
-    <summary>Native binaries of libpinmame for linux-x64</summary>
+    <description>This package complements the PinMame package and contains native binaries of libpinmame for ios-arm64</description>
+    <summary>Native binaries of libpinmame for ios-arm64</summary>
     <projectUrl>https://github.com/VisualPinball/pinmame-dotnet</projectUrl>
     <repository type="git" url="https://github.com/VisualPinball/pinmame-dotnet" />
     <tags>libpinmame binaries</tags>
@@ -22,9 +22,9 @@
   </metadata>
   <files>
     <!-- The build bits -->
-    <file src="targets\PinMame.Native.linux-x64.targets" target="build\netstandard2.1" />
-    <!-- Include libpinmame linux-x64 binaries -->
-    <file src="libpinmame-linux-x64\libpinmame.so.*" target="runtimes\linux-x64\native" />
+    <file src="targets\PinMame.Native.ios-arm64.targets" target="build\netstandard2.1" />
+    <!-- Include libpinmame ios-arm64 binaries -->
+    <file src="libpinmame-ios-arm64\libpinmame.*.dylib" target="runtimes\ios-arm64\native" />
     <!-- Include the license -->
     <file src="..\..\LICENSE.txt" />
     <!-- A dummy reference which prevents NuGet from adding any compilation references when this package is imported -->

--- a/native/nuget/PinMame.Native.nuspec
+++ b/native/nuget/PinMame.Native.nuspec
@@ -17,17 +17,18 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>PinMAME development team and contributors</copyright>
     <dependencies>
-      <group targetFramework="netstandard2.0">
+      <group targetFramework="netstandard2.1">
         <dependency id="PinMame.Native.win-x64" version="__VERSION__" include="native" />
         <dependency id="PinMame.Native.win-x86" version="__VERSION__" include="native" />
         <dependency id="PinMame.Native.osx-x64" version="__VERSION__" include="native" />
         <dependency id="PinMame.Native.osx-arm64" version="__VERSION__" include="native" />
+        <dependency id="PinMame.Native.ios-arm64" version="__VERSION__" include="native" />
         <dependency id="PinMame.Native.linux-x64" version="__VERSION__" include="native" />
       </group>
     </dependencies>
   </metadata>
   <files>
     <!-- A dummy reference which prevents NuGet from adding any compilation references when this package is imported -->
-    <file src="_._" target="lib\netstandard2.0" />
+    <file src="_._" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/native/nuget/PinMame.Native.osx-arm64.nuspec
+++ b/native/nuget/PinMame.Native.osx-arm64.nuspec
@@ -17,17 +17,17 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>PinMAME development team and contributors</copyright>
     <dependencies>
-      <group targetFramework=".NETStandard2.0" />
+      <group targetFramework="netstandard2.1" />
     </dependencies>
   </metadata>
   <files>
     <!-- The build bits -->
-    <file src="targets\PinMame.Native.osx-arm64.targets" target="build\netstandard2.0" />
+    <file src="targets\PinMame.Native.osx-arm64.targets" target="build\netstandard2.1" />
     <!-- Include libpinmame osx-arm64 binaries -->
     <file src="libpinmame-osx-arm64\libpinmame.*.dylib" target="runtimes\osx-arm64\native" />
     <!-- Include the license -->
     <file src="..\..\LICENSE.txt" />
     <!-- A dummy reference which prevents NuGet from adding any compilation references when this package is imported -->
-    <file src="_._" target="lib\netstandard2.0" />
+    <file src="_._" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/native/nuget/PinMame.Native.osx-x64.nuspec
+++ b/native/nuget/PinMame.Native.osx-x64.nuspec
@@ -17,17 +17,17 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>PinMAME development team and contributors</copyright>
     <dependencies>
-      <group targetFramework=".NETStandard2.0" />
+      <group targetFramework="netstandard2.1" />
     </dependencies>
   </metadata>
   <files>
     <!-- The build bits -->
-    <file src="targets\PinMame.Native.osx-x64.targets" target="build\netstandard2.0" />
+    <file src="targets\PinMame.Native.osx-x64.targets" target="build\netstandard2.1" />
     <!-- Include libpinmame osx-x64 binaries -->
     <file src="libpinmame-osx-x64\libpinmame.*.dylib" target="runtimes\osx-x64\native" />
     <!-- Include the license -->
     <file src="..\..\LICENSE.txt" />
     <!-- A dummy reference which prevents NuGet from adding any compilation references when this package is imported -->
-    <file src="_._" target="lib\netstandard2.0" />
+    <file src="_._" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/native/nuget/PinMame.Native.win-x64.nuspec
+++ b/native/nuget/PinMame.Native.win-x64.nuspec
@@ -17,17 +17,17 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>PinMAME development team and contributors</copyright>
     <dependencies>
-      <group targetFramework=".NETStandard2.0" />
+      <group targetFramework="netstandard2.1" />
     </dependencies>
   </metadata>
   <files>
     <!-- The build bits -->
-    <file src="targets\PinMame.Native.win-x64.targets" target="build\netstandard2.0" />
+    <file src="targets\PinMame.Native.win-x64.targets" target="build\netstandard2.1" />
     <!-- Include libpinmame win-x64 binaries -->
     <file src="libpinmame-win-x64\libpinmame-*.dll" target="runtimes\win-x64\native" />
     <!-- Include the license -->
     <file src="..\..\LICENSE.txt" />
     <!-- A dummy reference which prevents NuGet from adding any compilation references when this package is imported -->
-    <file src="_._" target="lib\netstandard2.0" />
+    <file src="_._" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/native/nuget/PinMame.Native.win-x86.nuspec
+++ b/native/nuget/PinMame.Native.win-x86.nuspec
@@ -17,17 +17,17 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>PinMAME development team and contributors</copyright>
     <dependencies>
-      <group targetFramework=".NETStandard2.0" />
+      <group targetFramework="netstandard2.1" />
     </dependencies>
   </metadata>
   <files>
     <!-- The build bits -->
-    <file src="targets\PinMame.Native.win-x86.targets" target="build\netstandard2.0" />
+    <file src="targets\PinMame.Native.win-x86.targets" target="build\netstandard2.1" />
     <!-- Include libpinmame win-x86 binaries -->
     <file src="libpinmame-win-x86\libpinmame-*.dll" target="runtimes\win-x86\native" />
     <!-- Include the license -->
     <file src="..\..\LICENSE.txt" />
     <!-- A dummy reference which prevents NuGet from adding any compilation references when this package is imported -->
-    <file src="_._" target="lib\netstandard2.0" />
+    <file src="_._" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/native/nuget/targets/PinMame.Native.ios-arm64.targets
+++ b/native/nuget/targets/PinMame.Native.ios-arm64.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="'$(MSBuildRuntimeType)' == 'Mono'">
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios-arm64\native\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/PinMame/Interop/Libraries.iOS.cs
+++ b/src/PinMame/Interop/Libraries.iOS.cs
@@ -1,0 +1,38 @@
+// pinmame-dotnet
+// Copyright (C) 1999-2022 PinMAME development team and contributors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions 
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright 
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the 
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+
+namespace PinMame.Interop
+{
+	internal static partial class Libraries
+	{
+		internal const string PinMame = "libpinmame.3.5.dylib";
+	}
+}

--- a/src/PinMame/Mono/MonoPInvokeCallbackAttribute.cs
+++ b/src/PinMame/Mono/MonoPInvokeCallbackAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+
+/*!
+ * @brief	attribute that allows static functions to have callbacks (from C) generated AOT
+ */
+public class MonoPInvokeCallbackAttribute : Attribute
+{
+    private Type type;
+
+    public MonoPInvokeCallbackAttribute(Type t)
+    {
+        type = t;
+    }
+}

--- a/src/PinMame/PinMame.cs
+++ b/src/PinMame/PinMame.cs
@@ -230,16 +230,16 @@ namespace PinMame
 				audioFormat = (PinMameApi.PinmameAudioFormat)audioFormat,
 				sampleRate = sampleRate,
 				vpmPath = path + Path.DirectorySeparatorChar,
-				onStateUpdated = OnStateUpdatedCallback,
-				onDisplayAvailable = OnDisplayAvailableCallback,
-				onDisplayUpdated = OnDisplayUpdatedCallback,
-				onAudioAvailable = OnAudioAvailableCallback,
-				onAudioUpdated = OnAudioUpdatedCallback,
-				onMechAvailable = OnMechAvailableCallback,
-				onMechUpdated = OnMechUpdatedCallback,
-				onSolenoidUpdated = OnSolenoidUpdatedCallback,
-				onConsoleDataUpdated = OnConsoleDataUpdatedCallback,
-				isKeyPressed = IsKeyPressedFunction,
+				onStateUpdated = OnStateUpdatedCallbackPInvoke,
+				onDisplayAvailable = OnDisplayAvailableCallbackPInvoke,
+				onDisplayUpdated = OnDisplayUpdatedCallbackPInvoke,
+				onAudioAvailable = OnAudioAvailableCallbackPInvoke,
+				onAudioUpdated = OnAudioUpdatedCallbackPInvoke,
+				onMechAvailable = OnMechAvailableCallbackPInvoke,
+				onMechUpdated = OnMechUpdatedCallbackPInvoke,
+				onSolenoidUpdated = OnSolenoidUpdatedCallbackPInvoke,
+				onConsoleDataUpdated = OnConsoleDataUpdatedCallbackPInvoke,
+				isKeyPressed = IsKeyPressedFunctionPInvoke,
 			};
 			PinMameApi.PinmameSetConfig(ref _config);
 		}
@@ -436,6 +436,12 @@ namespace PinMame
 			}
 		}
 
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameOnStateUpdatedCallback))]
+		private static void OnStateUpdatedCallbackPInvoke(int state)
+		{
+			_instance.OnStateUpdatedCallback(state);
+		}
+
 		private void OnStateUpdatedCallback(int state)
 		{
 			Logger.Debug($"OnStateUpdatedCallback - state={state}");
@@ -452,6 +458,12 @@ namespace PinMame
 			}
 		}
 
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameOnDisplayAvailableCallback))]
+		private static void OnDisplayAvailableCallbackPInvoke(int index, int displayCount, ref PinMameApi.PinmameDisplayLayout displayLayoutRef)
+		{
+			_instance.OnDisplayAvailableCallback(index, displayCount, ref displayLayoutRef);
+		}
+
 		private void OnDisplayAvailableCallback(int index, int displayCount, ref PinMameApi.PinmameDisplayLayout displayLayoutRef)
 		{
 			var displayLayout = new PinMameDisplayLayout(displayLayoutRef, PinMameApi.PinmameGetHardwareGen());
@@ -459,6 +471,12 @@ namespace PinMame
 			Logger.Trace($"OnDisplayAvailableCallback - index={index}, displayCount={displayCount}, displayLayout={displayLayout}");
 
 			OnDisplayAvailable?.Invoke(index, displayCount, displayLayout);
+		}
+
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameOnDisplayUpdatedCallback))]
+		private static void OnDisplayUpdatedCallbackPInvoke(int index, IntPtr framePtr, ref PinMameApi.PinmameDisplayLayout displayLayoutRef)
+		{
+			_instance.OnDisplayUpdatedCallback(index, framePtr, ref displayLayoutRef);
 		}
 
 		private void OnDisplayUpdatedCallback(int index, IntPtr framePtr, ref PinMameApi.PinmameDisplayLayout displayLayoutRef)
@@ -470,8 +488,14 @@ namespace PinMame
 			OnDisplayUpdated?.Invoke(index, framePtr, displayLayout);
 		}
 
-		private int OnAudioAvailableCallback(ref PinMameApi.PinmameAudioInfo audioInfoRef)
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameOnAudioAvailableCallback))]
+		private static int OnAudioAvailableCallbackPInvoke(ref PinMameApi.PinmameAudioInfo audioInfoRef)
 		{
+			return _instance.OnAudioAvailableCallback(ref audioInfoRef);
+		}
+
+		private int OnAudioAvailableCallback(ref PinMameApi.PinmameAudioInfo audioInfoRef)
+		{ 
 			var audioInfo = new PinMameAudioInfo(audioInfoRef);
 
 			Logger.Trace($"OnAudioAvailableCallback - audioInfo={audioInfo}");
@@ -479,11 +503,23 @@ namespace PinMame
 			return OnAudioAvailable?.Invoke(audioInfo) ?? 0;
 		}
 
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameOnAudioUpdatedCallback))]
+		private static int OnAudioUpdatedCallbackPInvoke(IntPtr bufferPtr, int samples)
+		{
+			return _instance.OnAudioUpdatedCallback(bufferPtr, samples);
+		}
+
 		private int OnAudioUpdatedCallback(IntPtr bufferPtr, int samples)
 		{
 			Logger.Trace($"OnAudioUpdatedCallback - samples={samples}");
 
 			return OnAudioUpdated?.Invoke(bufferPtr, samples) ?? 0;
+		}
+
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameOnMechAvailableCallback))]
+		private static void OnMechAvailableCallbackPInvoke(int mechNo, ref PinMameApi.PinmameMechInfo mechInfoRef)
+		{
+			_instance.OnMechAvailableCallback(mechNo, ref mechInfoRef);
 		}
 
 		private void OnMechAvailableCallback(int mechNo, ref PinMameApi.PinmameMechInfo mechInfoRef)
@@ -495,20 +531,38 @@ namespace PinMame
 			OnMechAvailable?.Invoke(mechNo, mechInfo);
 		}
 
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameOnMechUpdatedCallback))]
+		private static void OnMechUpdatedCallbackPInvoke(int mechNo, ref PinMameApi.PinmameMechInfo mechInfoRef)
+		{
+			_instance.OnMechUpdatedCallback(mechNo, ref mechInfoRef);
+		}
+
 		private void OnMechUpdatedCallback(int mechNo, ref PinMameApi.PinmameMechInfo mechInfoRef)
 		{
 			var mechInfo = new PinMameMechInfo(mechInfoRef);
 
 			Logger.Trace($"OnMechUpdatedCallback - mechNo={mechNo}, mechInfo={mechInfo}");
 
-			OnMechUpdated?.Invoke(mechNo, mechInfo);
+			_instance.OnMechUpdated?.Invoke(mechNo, mechInfo);
+		}
+
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameOnSolenoidUpdatedCallback))]
+		private static void OnSolenoidUpdatedCallbackPInvoke(int solenoid, int isActive)
+		{
+			_instance.OnSolenoidUpdatedCallback(solenoid, isActive);
 		}
 
 		private void OnSolenoidUpdatedCallback(int solenoid, int isActive)
-		{
+		{ 
 			Logger.Debug($"OnSolenoidUpdatedCallback - solenoid={solenoid}, isActive={isActive}");
 
 			OnSolenoidUpdated?.Invoke(solenoid, isActive == 1);
+		}
+
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameOnConsoleDataUpdatedCallback))]
+		private static void OnConsoleDataUpdatedCallbackPInvoke(IntPtr dataPtr, int size)
+		{
+			_instance.OnConsoleDataUpdatedCallback(dataPtr, size);
 		}
 
 		private void OnConsoleDataUpdatedCallback(IntPtr dataPtr, int size)
@@ -516,6 +570,12 @@ namespace PinMame
 			Logger.Debug($"OnConsoleDataUpdatedCallback - size={size}");
 
 			OnConsoleDataUpdated?.Invoke(dataPtr, size);
+		}
+
+		[MonoPInvokeCallback(typeof(PinMameApi.PinmameIsKeyPressedFunction))]
+		private static int IsKeyPressedFunctionPInvoke(PinMameApi.PinmameKeycode keycode)
+		{
+			return _instance.IsKeyPressedFunction(keycode);
 		}
 
 		private int IsKeyPressedFunction(PinMameApi.PinmameKeycode keycode)

--- a/src/PinMame/PinMame.csproj
+++ b/src/PinMame/PinMame.csproj
@@ -26,8 +26,8 @@
     <TargetOS Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</TargetOS>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0"/>
-    <PackageReference Include="NLog" Version="4.7.13"/>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="NLog" Version="4.7.13" />
   </ItemGroup>
   <!-- Append target operating system to output path -->
   <PropertyGroup>
@@ -39,12 +39,16 @@
       <Link>Interop\Libraries.cs</Link>
     </Compile>
   </ItemGroup>
-  <!-- Include .NET Standard packages on Linux and macOS -->
+  <!-- Include .NET Standard packages on macOS, iOS, and Linux -->
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\Linux\PinMame.dll" Pack="true" PackagePath="runtimes\linux\lib\netstandard2.1"/>
-    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\OSX\PinMame.dll" Pack="true" PackagePath="runtimes\osx\lib\netstandard2.1"/>
+    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\OSX\PinMame.dll" Pack="true" PackagePath="runtimes\osx\lib\netstandard2.1" />
+    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\iOS\PinMame.dll" Pack="true" PackagePath="runtimes\ios\lib\netstandard2.1" />
+    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\Linux\PinMame.dll" Pack="true" PackagePath="runtimes\linux\lib\netstandard2.1" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Mono\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
While trying to get Visual Pinball Engine running on iOS, I ran into following error:

```
VisualPinball.Engine.PinMAME.PinMameGamelogicEngine:OnInit(Player, TableApi, BallManager)
NotSupportedException: IL2CPP does not support marshaling delegates that point to instance methods to native code. The method we're attempting to marshal is: PinMame.PinMame::OnStateUpdatedCallback
  at PinMame.PinMameApi.PinmameSetConfig (PinMame.PinMameApi+PinmameConfig& config) [0x00000] in <00000000000000000000000000000000>:0 
```

After updating the callbacks to be static, another error occurred:

```
To marshal a managed method, please add an attribute named 'MonoPInvokeCallback' to the method definition
```

After reviewing https://github.com/discord/discord-rpc/issues/186 I was able to implement [MonoPInvokeCallbackAttribute.cs](https://github.com/sphero-inc/UNITY-PLUGIN/blob/master/Plugins/Sphero/MonoPInvokeCallbackAttribute.cs) from [this](https://github.com/sphero-inc/UNITY-PLUGIN) repo.


Todo:

- [x] Better way of doing the static methods?
- [x] Test in Windows + Mac. 

