### PR TITLE
android: add support for android-arm64-v8a

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,17 @@ jobs:
             rid: osx-x64
           - os: macos-latest
             rid: osx-arm64
+            skipTest: true
           - os: macos-latest
             rid: ios-arm64
+            targetOS: iOS
+            skipTest: true
           - os: ubuntu-latest
             rid: linux-x64
+          - os: ubuntu-latest
+            rid: android-arm64-v8a
+            targetOS: Android
+            skipTest: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
@@ -41,13 +48,13 @@ jobs:
       - name: Build
         run: |
           cd src/PinMame.Tests
-          if [[ "${{ matrix.rid }}" == "ios-arm64" ]]; then
-            dotnet build -c Release -r ${{ matrix.rid }} /p:TargetOS=iOS
+          if [[ "${{ matrix.targetOS }}" ]]; then
+            dotnet build -c Release -r ${{ matrix.rid }} /p:TargetOS=${{ matrix.targetOS }}
           else
             dotnet build -c Release -r ${{ matrix.rid }}
           fi
       - name: Test
-        if: matrix.rid != 'osx-arm64' && matrix.rid != 'ios-arm64'
+        if: matrix.skipTest != true
         run: |
           mkdir -p ~/.pinmame/roms
           curl -sl https://www.ipdb.org/files/4032/mm_109c.zip -o ~/.pinmame/roms/mm_109c.zip

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -42,6 +42,7 @@ jobs:
           mv libpinmame-*-osx-arm64 libpinmame-osx-arm64
           mv libpinmame-*-ios-arm64 libpinmame-ios-arm64
           mv libpinmame-*-linux-x64 libpinmame-linux-x64
+          mv libpinmame-*-android-arm64-v8a libpinmame-android-arm64-v8a
           sed -i 's/__VERSION__/${{ needs.version.outputs.semver }}/g' *.nuspec
           nuget pack PinMame.Native.win-x64.nuspec -OutputDirectory nupkg
           nuget pack PinMame.Native.win-x86.nuspec -OutputDirectory nupkg
@@ -49,6 +50,7 @@ jobs:
           nuget pack PinMame.Native.osx-arm64.nuspec -OutputDirectory nupkg
           nuget pack PinMame.Native.ios-arm64.nuspec -OutputDirectory nupkg
           nuget pack PinMame.Native.linux-x64.nuspec -OutputDirectory nupkg
+          nuget pack PinMame.Native.android-arm64-v8a.nuspec -OutputDirectory nupkg
           nuget pack PinMame.Native.nuspec -OutputDirectory nupkg
       - uses: actions/upload-artifact@v2
         with:
@@ -72,3 +74,4 @@ jobs:
           nuget push PinMame.Native.osx-arm64.${{ needs.version.outputs.semver }}.nupkg -ApiKey ${{ secrets.NUGET_KEY }} -src https://api.nuget.org/v3/index.json
           nuget push PinMame.Native.ios-arm64.${{ needs.version.outputs.semver }}.nupkg -ApiKey ${{ secrets.NUGET_KEY }} -src https://api.nuget.org/v3/index.json
           nuget push PinMame.Native.linux-x64.${{ needs.version.outputs.semver }}.nupkg -ApiKey ${{ secrets.NUGET_KEY }} -src https://api.nuget.org/v3/index.json
+          nuget push PinMame.Native.android-arm64-v8a.${{ needs.version.outputs.semver }}.nupkg -ApiKey ${{ secrets.NUGET_KEY }} -src https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
           ref: ${{ github.event.client_payload.commitish }}
       - run: |
           cd src/PinMame
+          dotnet build -c Release /p:TargetOS=Android
           dotnet build -c Release /p:TargetOS=iOS
           dotnet build -c Release /p:TargetOS=OSX
           dotnet build -c Release /p:TargetOS=Linux

--- a/native/nuget/PinMame.Native.android-arm64-v8a.nuspec
+++ b/native/nuget/PinMame.Native.android-arm64-v8a.nuspec
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
+  <metadata>
+    <!-- package -->
+    <id>PinMame.Native.android-arm64-v8a</id>
+    <title>PinMame - Native binaries for android-arm64-v8a</title>
+    <version>__VERSION__</version>
+    <description>This package complements the PinMame package and contains native binaries of libpinmame for android-arm64-v8a</description>
+    <summary>Native binaries of libpinmame for android-arm64-v8a</summary>
+    <projectUrl>https://github.com/VisualPinball/pinmame-dotnet</projectUrl>
+    <repository type="git" url="https://github.com/VisualPinball/pinmame-dotnet" />
+    <tags>libpinmame binaries</tags>
+    <!-- legal -->
+    <license type="expression">BSD-3-Clause</license>
+    <authors>Jason Millard</authors>
+    <owners>PinMAME development team and contributors</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>PinMAME development team and contributors</copyright>
+    <dependencies>
+      <group targetFramework="netstandard2.1" />
+    </dependencies>
+  </metadata>
+  <files>
+    <!-- The build bits -->
+    <file src="targets\PinMame.Native.android-arm64-v8a.targets" target="build\netstandard2.1" />
+    <!-- Include libpinmame android-arm64-v8a binaries -->
+    <file src="libpinmame-android-arm64-v8a\libpinmame.*.so" target="runtimes\android-arm64-v8a\native" />
+    <!-- Include the license -->
+    <file src="..\..\LICENSE.txt" />
+    <!-- A dummy reference which prevents NuGet from adding any compilation references when this package is imported -->
+    <file src="_._" target="lib\netstandard2.1" />
+  </files>
+</package>

--- a/native/nuget/PinMame.Native.nuspec
+++ b/native/nuget/PinMame.Native.nuspec
@@ -24,6 +24,7 @@
         <dependency id="PinMame.Native.osx-arm64" version="__VERSION__" include="native" />
         <dependency id="PinMame.Native.ios-arm64" version="__VERSION__" include="native" />
         <dependency id="PinMame.Native.linux-x64" version="__VERSION__" include="native" />
+        <dependency id="PinMame.Native.android-arm64-v8a" version="__VERSION__" include="native" />
       </group>
     </dependencies>
   </metadata>

--- a/native/nuget/targets/PinMame.Native.android-arm64-v8a.targets
+++ b/native/nuget/targets/PinMame.Native.android-arm64-v8a.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="'$(MSBuildRuntimeType)' == 'Mono'">
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\android-arm64-v8a\native\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/PinMame.Example/PinMame.Example.csproj
+++ b/src/PinMame.Example/PinMame.Example.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.6" />
+    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.12" />
     <PackageReference Include="NLog" Version="4.7.13" />
   </ItemGroup>
 

--- a/src/PinMame.Tests/PinMame.Tests.csproj
+++ b/src/PinMame.Tests/PinMame.Tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.6" />
+    <PackageReference Include="PinMame.Native" Version="3.5.0-preview.12" />
   </ItemGroup>
     
 </Project>

--- a/src/PinMame/Interop/Libraries.Android.cs
+++ b/src/PinMame/Interop/Libraries.Android.cs
@@ -1,0 +1,38 @@
+// pinmame-dotnet
+// Copyright (C) 1999-2022 PinMAME development team and contributors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions 
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright 
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the 
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+
+namespace PinMame.Interop
+{
+	internal static partial class Libraries
+	{
+		internal const string PinMame = "libpinmame.3.5.so";
+	}
+}

--- a/src/PinMame/PinMame.csproj
+++ b/src/PinMame/PinMame.csproj
@@ -26,8 +26,8 @@
     <TargetOS Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</TargetOS>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0"/>
-    <PackageReference Include="NLog" Version="4.7.13"/>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="NLog" Version="4.7.13" />
   </ItemGroup>
   <!-- Append target operating system to output path -->
   <PropertyGroup>
@@ -39,16 +39,14 @@
       <Link>Interop\Libraries.cs</Link>
     </Compile>
   </ItemGroup>
-  <!-- Include .NET Standard packages on macOS, iOS, and Linux -->
+  <!-- Include .NET Standard packages on macOS, iOS, Linux, and Android -->
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\OSX\PinMame.dll" Pack="true" PackagePath="runtimes\osx\lib\netstandard2.1"/>
-    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\iOS\PinMame.dll" Pack="true" PackagePath="runtimes\ios\lib\netstandard2.1"/>
-    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\Linux\PinMame.dll" Pack="true" PackagePath="runtimes\linux\lib\netstandard2.1"/>
+    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\OSX\PinMame.dll" Pack="true" PackagePath="runtimes\osx\lib\netstandard2.1" />
+    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\iOS\PinMame.dll" Pack="true" PackagePath="runtimes\ios\lib\netstandard2.1" />
+    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\Linux\PinMame.dll" Pack="true" PackagePath="runtimes\linux\lib\netstandard2.1" />
+    <None Include="$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\netstandard2.1\Android\PinMame.dll" Pack="true" PackagePath="runtimes\android\lib\netstandard2.1" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Mono\"/>
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
 </Project>

--- a/src/PinMame/PinMame.sln
+++ b/src/PinMame/PinMame.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.810.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PinMame", "PinMame.csproj", "{AF8DAF33-CE72-46E7-A3A1-C9D97446AC6B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AF8DAF33-CE72-46E7-A3A1-C9D97446AC6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF8DAF33-CE72-46E7-A3A1-C9D97446AC6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF8DAF33-CE72-46E7-A3A1-C9D97446AC6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF8DAF33-CE72-46E7-A3A1-C9D97446AC6B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0D45A3CE-CA38-4C15-86C1-A95AD5B731C9}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
The PR adds support for `android-arm64-v8a`.

`libpinmame` follows Linux library naming conventions, ie: `libpinmame.so.3.5`

Android will not include native libraries when the extension is not `.so`:

https://stackoverflow.com/questions/42813480/how-to-include-versioned-so-file-into-apk-using-gradle

Unity also only accepts files ending with `.so`, so this helps there as well.

(We may have to switch the Linux builds as well to support Unity) 